### PR TITLE
Adding share context between clients and improved first call

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ TrackSeries TheTVDBClient
 # Installing via NuGet
 
 ```
-dotnet add package TrackSeries.TheTVDB.Client --version 0.1.1-pre
+dotnet add package TrackSeries.TheTVDB.Client --version 0.1.3-pre
 ``` 
 
 ```
-Install-Package TrackSeries.TheTVDB.Client -Version 0.1.1-pre
+Install-Package TrackSeries.TheTVDB.Client -Version 0.1.3-pre
 ```
 
 # Getting Started
@@ -35,6 +35,15 @@ Now you will be able to use the endpoints under `Users`:
 
 ```C#
 var userFavoriteSeries = await client.Users.GetFavoritesAsync();
+```
+It's possible to share the context between all the instances of the client (token and language):
+
+```C#
+services.AddTVDBClient(options => 
+{
+    options.ApiKey = "Set here your API-KEY for TheTVDB";
+    options.ShareContextBetweenClients = true;
+});
 ```
 
 # Acknowledgements

--- a/src/TrackSeries.TheTVDB.Client/BaseClient.cs
+++ b/src/TrackSeries.TheTVDB.Client/BaseClient.cs
@@ -163,6 +163,13 @@ namespace TrackSeries.TheTVDB.Client
 
         protected async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default) 
         {
+            // If we don't have a token we don't want to wait since we know we will get an unauthorized. 
+            // Let's try to get a valid token first.
+            if(string.IsNullOrEmpty(_context.Token))
+            {
+                await TryObtainValidTokenAsync(cancellationToken);
+            }
+
             PrepareRequest(request);
             var response = await _client.SendAsync(request, cancellationToken);
 

--- a/src/TrackSeries.TheTVDB.Client/IServiceCollectionExtensions.cs
+++ b/src/TrackSeries.TheTVDB.Client/IServiceCollectionExtensions.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddTVDBClient(this IServiceCollection services, Action<TVDBClientOptions> configureOptions)
         {
             services.AddOptions();
-
             services.Configure(configureOptions);
+
+            services.TryAddSingleton<TVDBContext>();
 
             services.AddHttpClient<ITVDBClient, TVDBClient>((provider, client) =>
             {

--- a/src/TrackSeries.TheTVDB.Client/TVDBClient.cs
+++ b/src/TrackSeries.TheTVDB.Client/TVDBClient.cs
@@ -13,9 +13,13 @@ namespace TrackSeries.TheTVDB.Client
     public class TVDBClient : ITVDBClient
     {
         public TVDBClient(
-            HttpClient client, IOptions<TVDBClientOptions> options)
+            HttpClient client, IOptions<TVDBClientOptions> options, TVDBContext context)
         {
-            var context = new TVDBContext();
+            if (!options.Value.ShareContextBetweenClients)
+            {
+                // If we don't want to share the context, we are creating one just for this client
+                context = new TVDBContext();
+            }
 
             Series = new SeriesClient(client, options, context);
             Search = new SearchClient(client, options, context);

--- a/src/TrackSeries.TheTVDB.Client/TVDBClientOptions.cs
+++ b/src/TrackSeries.TheTVDB.Client/TVDBClientOptions.cs
@@ -5,5 +5,6 @@
         public string ApiKey { get; set; }
         internal string BaseAddress { get; set; } = "https://api.thetvdb.com";
         public string AcceptedLanguage { get; set; } = "en";
+        public bool ShareContextBetweenClients { get; set; } = false;
     }
 }

--- a/src/TrackSeries.TheTVDB.Client/TVDBContext.cs
+++ b/src/TrackSeries.TheTVDB.Client/TVDBContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace TrackSeries.TheTVDB.Client
 {
-    internal class TVDBContext
+    public class TVDBContext
     {
         public string Token { get; private set; }
         public string Language { get; set; }

--- a/src/TrackSeries.TheTVDB.Client/TrackSeries.TheTVDB.Client.csproj
+++ b/src/TrackSeries.TheTVDB.Client/TrackSeries.TheTVDB.Client.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>git://github.com/TrackSeries/TrackSeries.TheTVDB.Client</RepositoryUrl>
     <PackageTags>TheTVDB;Client</PackageTags>
     <Company>TrackSeries</Company>
-    <Version>0.1.1-pre</Version>
+    <Version>0.1.3-pre</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adding possibility of sharing context between clients. That way, if we are not relaying on different TheTVDB users between clients, we can avoid requesting a new token every time a new client is resolved. 

- When there's no token now we request one instead of just awaiting to get an unauthorized and retrying.