### PR TITLE
Trying to read configuration from IConfiguration as PostConfigure

### DIFF
--- a/src/TrackSeries.TheTVDB.Client/IServiceCollectionExtensions.cs
+++ b/src/TrackSeries.TheTVDB.Client/IServiceCollectionExtensions.cs
@@ -12,10 +12,14 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class IServiceCollectionExtensions
     {
-        public static IServiceCollection AddTVDBClient(this IServiceCollection services, Action<TVDBClientOptions> configureOptions)
+        public static IServiceCollection AddTVDBClient(this IServiceCollection services, Action<TVDBClientOptions> configureOptions = null)
         {
             services.AddOptions();
-            services.Configure(configureOptions);
+
+            if(configureOptions != null)
+            {
+                services.Configure(configureOptions);
+            }
 
             services.TryAddSingleton<TVDBContext>();
 

--- a/src/TrackSeries.TheTVDB.Client/TVDBClientPostConfigureOptions.cs
+++ b/src/TrackSeries.TheTVDB.Client/TVDBClientPostConfigureOptions.cs
@@ -1,13 +1,22 @@
 ﻿using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
-using TrackSeries.TheTVDB.Client.Languages;
 
 namespace TrackSeries.TheTVDB.Client
 {
     internal class TVDBClientPostConfigureOptions : IPostConfigureOptions<TVDBClientOptions>
     {
+        private readonly IConfiguration _configuration;
+
+        public TVDBClientPostConfigureOptions(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
         public void PostConfigure(string name, TVDBClientOptions options)
         {
+            Initialize(options);
+
             if (string.IsNullOrEmpty(options.ApiKey))
             {
                 throw new InvalidOperationException("ApiKey must be configured.");
@@ -21,6 +30,19 @@ namespace TrackSeries.TheTVDB.Client
             if (string.IsNullOrEmpty(options.AcceptedLanguage))
             {
                 options.AcceptedLanguage = "en";
+            }
+        }
+
+        private void Initialize(TVDBClientOptions options)
+        {
+            //If there's no ApiKey let's try to read values from Configuration
+            if (string.IsNullOrEmpty(options.ApiKey))
+            {
+                var newOptions = _configuration.GetSection(nameof(TVDBClientOptions)).Get<TVDBClientOptions>();
+                options.ApiKey = newOptions.ApiKey;
+                options.AcceptedLanguage = newOptions.AcceptedLanguage;
+                options.ReturnCompleteUrlForImages = newOptions.ReturnCompleteUrlForImages;
+                options.ShareContextBetweenClients = newOptions.ShareContextBetweenClients;
             }
         }
     }

--- a/tests/BasicTest/Program.cs
+++ b/tests/BasicTest/Program.cs
@@ -23,9 +23,13 @@ namespace BasicTest
                 .AddUserSecrets(assembly: typeof(Program).Assembly)
                 .Build();
 
+            services.AddSingleton<IConfiguration>(configuration);
+
             services.AddTVDBClient(options =>
             {
                 options.ApiKey = configuration["ApiKey"];
+                options.ShareContextBetweenClients = true;
+                options.ReturnCompleteUrlForImages = true;
             });
 
             var provider = services.BuildServiceProvider();


### PR DESCRIPTION
When `TVDBClientOptions` are not configured, either via `AddTVDBClient(Action<TVDBClientOptions> configureOptions)` or calling `services.Configure()`, it will try to automatically read the configuration from `IConfiguration` looking for the key **TVDBClientOptions**.