### PR TITLE
Update ImageConverter logic

### DIFF
--- a/src/TrackSeries.TheTVDB.Client/ImageConverter.cs
+++ b/src/TrackSeries.TheTVDB.Client/ImageConverter.cs
@@ -15,7 +15,7 @@ internal static class ImageConverter
             return input;
         }
 
-        if (!input.Contains(Banners))
+        if (!input.StartsWith(Banners))
         {
             input = Banners + input;
         }

--- a/tests/BasicTest/Program.cs
+++ b/tests/BasicTest/Program.cs
@@ -67,6 +67,8 @@ class Program
         var rating = await tvdb.Users.AddSeriesRatingAsync(328724, 10);
         //var favorite = await tvdb.Users.AddToFavoritesAsync(328724);
 
+        var starwars = await tvdb.Series.GetAsync(420659);
+
         // Game of Thrones with information in English
         var gameofthrones = await tvdb.Series.GetAsync(121361);
 


### PR DESCRIPTION
This pull request includes a minor fix to image URL handling and adds a new test call to retrieve a series by ID. The most important changes are:

Image URL handling:

* Updated the `CheckAndConvertToCompleteUrl` method in `ImageConverter.cs` to check if the input starts with the `Banners` prefix instead of just containing it, ensuring more accurate URL construction.

Test coverage:

* Added a call in `Program.cs` to fetch the "Star Wars" series by its ID (420659), which helps verify the series retrieval functionality.Modified the `ImageConverter` class to check if `input` starts with `Banners` instead of checking if it contains `Banners` before appending the prefix. This ensures the prefix is only added when necessary.